### PR TITLE
Fix: Correct Gemini model name

### DIFF
--- a/src/services/geminiService.js
+++ b/src/services/geminiService.js
@@ -11,7 +11,7 @@ class GeminiService {
         }
         
         this.genAI = new GoogleGenerativeAI(apiKey);
-        this.model = this.genAI.getGenerativeModel({ model: "gemini-2.0-lite" });
+        this.model = this.genAI.getGenerativeModel({ model: "gemini-2.0-flash-lite" });
         
         // System prompt for the AI tutor
         this.systemPrompt = `You are an expert AI tutor specializing in technology and artificial intelligence education. Your role is to:


### PR DESCRIPTION
The previous model name "gemini-2.0-lite" was incorrect and causing an API error. This commit updates the model name to "gemini-2.0-flash-lite", which is a valid and available model.